### PR TITLE
Supply -assume-filename to clang-format

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1064,6 +1064,7 @@ impl Server {
 
         let child = match Command::new(&self.args.fmt_exe)
             .arg(format!("-style={}", self.args.fmt_style))
+            .arg("-assume-filename=foo.scad")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .spawn()


### PR DESCRIPTION
I want to supply my own format via `-style=file` which instructs the formatter to load settings from `.clang-format` file in the project directory or containing directory (i.e. home directory). 

However I got error messages since clang-format can't auto-detect the language when input comes from stdin. This PR uses clang-format's supported method to supply an example filename for the purposes of language detection, so it runs the same as if clang-format were run directly on the file.

BTW, I created some reasonable initial settings via:
```
clang-format --style '{BasedOnStyle: llvm, SpacesInContainerLiterals: false, AllowShortBlocksOnASingleLine: false, AllowShortFunctionsOnASingleLine: false}' --dump-config >.clang-format
```
