### PR TITLE
update tree sitter grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,8 +488,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-openscad"
-version = "0.4.0"
-source = "git+https://github.com/Leathong/tree-sitter-openscad.git?branch=master#d72423b3ea2e6bbc31df82c2716aff1d70fb89ea"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061ff2ad938cb0e2f5a34202cc5e3f739738b97f124017150856d7721a21e2ac"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,9 @@ lsp-types = "0.93.1"
 serde = "1.0.145"
 serde_json = "1.0.86"
 tree-sitter = "0.20.9"
-tree-sitter-openscad = "0.4.0"
+tree-sitter-openscad = "0.4.2"
 linked-hash-map = "0.5.6"
 shellexpand = "2.1.2"
 clap = {features = ["derive"], version = "4.0.14"}
 lazy_static = "1.4.0"
 regex = "1.6.0"
-
-[patch.crates-io]
-tree-sitter-openscad = {git = "https://github.com/Leathong/tree-sitter-openscad.git", branch = "master"}

--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ Features
 Install
 ------------
 
-> There is a patch for '[tree-sitter-openscad](https://github.com/bollian/tree-sitter-openscad/pull/7)', you'd better building locally instead of downloading from crate.io, because the patch is not publish to crate.io for now (2022-10-13).
-
 openscad-LSP is written in [Rust](https://rust-lang.org), in order to use it, you need to
 install [Rust toolchain](https://www.rust-lang.org/learn/get-started).
 


### PR DESCRIPTION
The changes in https://github.com/bollian/tree-sitter-openscad/pull/7 are in the latest release so the fork is no longer needed.