### PR TITLE
stop using bool_to_option unstable feature

### DIFF
--- a/src/server/response_item.rs
+++ b/src/server/response_item.rs
@@ -46,10 +46,10 @@ impl Param {
         params
             .iter()
             .filter_map(|p| {
-                if !Server::get_server().args.ignore_default {
+                if !Server::get_server().args.ignore_default || p.default.is_none() {
                     Some(p)
                 } else {
-                    p.default.is_none().then_some(p)
+                    None
                 }
             })
             .enumerate()


### PR DESCRIPTION
Using `.then_some` here was causing `openscad-LSP` to not build on rustc stable.

Since it's the only unstable feature that it is using, I thought it would be good for us to remove this dependency.