### PR TITLE
feat: Added rename action support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,7 @@ dependencies = [
  "shellexpand",
  "tree-sitter",
  "tree-sitter-openscad",
+ "tree-sitter-traversal",
 ]
 
 [[package]]
@@ -570,6 +571,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "061ff2ad938cb0e2f5a34202cc5e3f739738b97f124017150856d7721a21e2ac"
 dependencies = [
  "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-traversal"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8a158225e4a4d8505f071340bba9edd109b23f01b70540dccb7c799868f307"
+dependencies = [
  "tree-sitter",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ clap = {features = ["derive"], version = "4.0.14"}
 lazy_static = "1.4.0"
 regex = "1.6.0"
 directories = "5.0.1"
+tree-sitter-traversal = "0.1.2"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Features
 -   function/module signatures on hover
 -   document symbols
 -   formatter, utilizing clang-format, you need install it yourself, it is not built-in.
+-   variable / module renaming
 -   hover and suggestion documentation, read from comments before the function/module.</br>
 
 

--- a/src/server/handler/mod.rs
+++ b/src/server/handler/mod.rs
@@ -6,7 +6,9 @@ use lsp_types::{
         DidChangeConfiguration, DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument,
         DidSaveTextDocument,
     },
-    request::{Completion, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest},
+    request::{
+        Completion, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest, Rename,
+    },
 };
 use serde_json::json;
 
@@ -69,6 +71,7 @@ impl Server {
                 let req = proc_req!(req, GotoDefinition, handle_definition);
                 let req = proc_req!(req, DocumentSymbolRequest, handle_document_symbols);
                 let req = proc_req!(req, Formatting, handle_formatting);
+                let req = proc_req!(req, Rename, handle_rename);
                 err_to_console!("unknown request: {:?}", req);
             }
             Message::Response(resp) => {

--- a/src/server/handler/request.rs
+++ b/src/server/handler/request.rs
@@ -60,12 +60,19 @@ impl Server {
             // unwrap here is fine because an identifier node should always have a parent scope
             let parent_scope = find_node_scope(node).unwrap();
 
+            let kind = parent_scope.kind();
+            let text = node_text(&bfile.code, &parent_scope);
+            dbg!(text, kind);
+
             (node_text(&bfile.code, &node), parent_scope, node)
         };
 
         let mut node_iter = traverse(parent_scope.walk(), Order::Post).peekable();
         let mut changes = vec![];
         while let Some(node) = node_iter.next() {
+            let kind = node.kind();
+            let text = node_text(&bfile.code, &node);
+            dbg!(text, kind);
             let is_identifier_instance =
                 node.kind() != "identifier" || node_text(&bfile.code, &node) != ident_initial_name;
             if is_identifier_instance {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,8 +13,8 @@ use std::{cell::RefCell, env, path::PathBuf, rc::Rc};
 use linked_hash_map::LinkedHashMap;
 use lsp_server::Connection;
 use lsp_types::{
-    HoverProviderCapability, OneOf, ServerCapabilities, TextDocumentSyncCapability,
-    TextDocumentSyncKind, Url,
+    HoverProviderCapability, OneOf, RenameOptions, ServerCapabilities, TextDocumentSyncCapability,
+    TextDocumentSyncKind, Url, WorkDoneProgressOptions,
 };
 
 use crate::parse_code::ParsedCode;
@@ -199,6 +199,10 @@ impl Server {
             hover_provider: Some(HoverProviderCapability::Simple(true)),
             document_symbol_provider: Some(OneOf::Left(true)),
             document_formatting_provider: Some(OneOf::Left(true)),
+            rename_provider: Some(OneOf::Right(RenameOptions {
+                prepare_provider: None,
+                work_done_progress_options: WorkDoneProgressOptions::default(),
+            })),
             ..Default::default()
         })?;
         self.connection.initialize(caps)?;

--- a/src/server/utils.rs
+++ b/src/server/utils.rs
@@ -39,7 +39,16 @@ pub(crate) fn find_node_scope(node: Node) -> Option<Node> {
             parent_node.kind(),
             "source_file" | "module_declaration" | "union_block"
         ) {
-            return Some(parent_node);
+            // If this is a module_declaration, the module will detect itself as
+            // its scope. So we need to check for that and get its scope's scope.
+            return if node
+                .parent()
+                .is_some_and(|parent| parent.kind() == "module_declaration")
+            {
+                find_node_scope(parent_scope)
+            } else {
+                Some(parent_node)
+            };
         }
     }
     None

--- a/src/server/utils.rs
+++ b/src/server/utils.rs
@@ -30,6 +30,21 @@ pub(crate) fn find_offset(text: &str, pos: Position) -> Option<usize> {
     Some(offset)
 }
 
+// Find the closest parent scope to the given node.
+pub(crate) fn find_node_scope(node: Node) -> Option<Node> {
+    let mut parent_scope = node;
+    while let Some(parent_node) = parent_scope.parent() {
+        parent_scope = parent_node;
+        if matches!(
+            parent_node.kind(),
+            "source_file" | "module_declaration" | "union_block"
+        ) {
+            return Some(parent_node);
+        }
+    }
+    None
+}
+
 pub(crate) fn to_position(p: Point) -> Position {
     Position {
         line: p.row as u32,

--- a/src/server/utils.rs
+++ b/src/server/utils.rs
@@ -30,6 +30,13 @@ pub(crate) fn find_offset(text: &str, pos: Position) -> Option<usize> {
     Some(offset)
 }
 
+pub(crate) fn to_position(p: Point) -> Position {
+    Position {
+        line: p.row as u32,
+        character: p.column as u32,
+    }
+}
+
 pub(crate) fn to_point(p: Position) -> Point {
     Point {
         row: p.line as usize,


### PR DESCRIPTION
closes #21

Implement the [Rename Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_rename) server capability.

Tested in Neovim v0.9.4

I've been playing a bit in OpenScad and have really been missing the Rename feature. Fortunately, this was easy enough with the code that was already written. If there's anything in need of change, let me know so I can fix it :)