### PR TITLE
Feat: prepare rename request

### DIFF
--- a/src/server/handler/mod.rs
+++ b/src/server/handler/mod.rs
@@ -7,7 +7,8 @@ use lsp_types::{
         DidSaveTextDocument,
     },
     request::{
-        Completion, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest, Rename,
+        Completion, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest,
+        PrepareRenameRequest, Rename,
     },
 };
 use serde_json::json;
@@ -71,6 +72,7 @@ impl Server {
                 let req = proc_req!(req, GotoDefinition, handle_definition);
                 let req = proc_req!(req, DocumentSymbolRequest, handle_document_symbols);
                 let req = proc_req!(req, Formatting, handle_formatting);
+                let req = proc_req!(req, PrepareRenameRequest, handle_prepare_rename);
                 let req = proc_req!(req, Rename, handle_rename);
                 err_to_console!("unknown request: {:?}", req);
             }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -190,7 +190,7 @@ impl Server {
     }
 
     pub(crate) fn main_loop(&mut self) -> Result<(), Box<dyn Error + Sync + Send>> {
-        let caps = serde_json::to_value(&ServerCapabilities {
+        let caps = serde_json::to_value(ServerCapabilities {
             text_document_sync: Some(TextDocumentSyncCapability::Kind(
                 TextDocumentSyncKind::INCREMENTAL,
             )),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -200,7 +200,7 @@ impl Server {
             document_symbol_provider: Some(OneOf::Left(true)),
             document_formatting_provider: Some(OneOf::Left(true)),
             rename_provider: Some(OneOf::Right(RenameOptions {
-                prepare_provider: None,
+                prepare_provider: Some(true),
                 work_done_progress_options: WorkDoneProgressOptions::default(),
             })),
             ..Default::default()


### PR DESCRIPTION
Implements the [Prepare Rename Request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_prepareRename).

The request handler is essentially a CTRL + C, CTRL + V of the rename request's beginning (can be seen [here](https://github.com/Leathong/openscad-LSP/blob/master/src/server/handler/request.rs#L36-L120)), but instead of showing an error message, it just returns `null` on most cases. I wanted to isolate the logic into a function (something like `fn can_rename_node (node: &Node, bfile: &ParsedCode) -> bool`) and reuse both in the Rename handler and the Prepare Rename Handler, but couldn't think of a good way to abstract it. So I'll just create this lazy PR and wait for feedback from the maintainer.