### PR TITLE
fix: hover on incorrect node

### DIFF
--- a/src/server/handler/request.rs
+++ b/src/server/handler/request.rs
@@ -24,8 +24,9 @@ use crate::{
     utils::*,
 };
 
-fn get_node_at_point<'a>(parsed_code: &'a Ref<'_, ParsedCode>, point: Point) -> Node<'a> {
+fn get_node_at_point<'a>(parsed_code: &'a Ref<'_, ParsedCode>, mut point: Point) -> Node<'a> {
     let mut cursor = parsed_code.tree.root_node().walk();
+    point.column += 1;
     while cursor.goto_first_child_for_point(point).is_some() {}
     cursor.node()
 }
@@ -45,6 +46,7 @@ impl Server {
 
         let (ident_initial_name, parent_scope, ident_initial_node) = {
             let node = get_node_at_point(&bfile, to_point(params.text_document_position.position));
+
             if node.kind() != "identifier" {
                 self.respond(Response {
                     id,
@@ -177,10 +179,7 @@ impl Server {
 
         let point = to_point(pos);
         let bfile = file.borrow();
-        let mut cursor = bfile.tree.root_node().walk();
-        while cursor.goto_first_child_for_point(point).is_some() {}
-
-        let node = cursor.node();
+        let node = get_node_at_point(&bfile, point);
 
         let kind = node.kind();
         let name = String::from(node_text(&bfile.code, &node));
@@ -226,10 +225,7 @@ impl Server {
 
         let point = to_point(pos);
         let bfile = file.borrow();
-        let mut cursor = bfile.tree.root_node().walk();
-        while cursor.goto_first_child_for_point(point).is_some() {}
-
-        let node = cursor.node();
+        let node = get_node_at_point(&bfile, point);
 
         let kind = node.kind();
         let name = String::from(node_text(&bfile.code, &node));
@@ -312,11 +308,7 @@ impl Server {
         }
 
         let bfile = file.borrow();
-        let mut cursor = bfile.tree.root_node().walk();
-
-        while cursor.goto_first_child_for_point(point).is_some() {}
-
-        let node = cursor.node();
+        let node = get_node_at_point(&bfile, point);
         let name = node_text(&bfile.code, &node);
 
         let mut items = self.find_identities(&file.borrow(), &|_| true, &node, true, 0);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -190,7 +190,7 @@ impl Server {
     }
 
     pub(crate) fn main_loop(&mut self) -> Result<(), Box<dyn Error + Sync + Send>> {
-        let caps = serde_json::to_value(&ServerCapabilities {
+        let caps = serde_json::to_value(ServerCapabilities {
             text_document_sync: Some(TextDocumentSyncCapability::Kind(
                 TextDocumentSyncKind::INCREMENTAL,
             )),


### PR DESCRIPTION
# Bug description

When hovering on the first letter of an identifier, it`d often show nothing.

# Steps to reproduce

1. Create a new scad file
2. open it in your editor, and write 
```
batata = 10;
cube(batata);
```
4. Hover on the first letter of the word `batata`.

Tested on Neovim v0.9.4

# Logs
Here are my LSP logs for the request/response:
```
[DEBUG][2023-12-16 00:30:19] .../vim/lsp/rpc.lua:284    "rpc.send"      {
  id = 3,
  jsonrpc = "2.0",
  method = "textDocument/hover",
  params = {
    position = {
      character = 5,
      line = 1
    },
    textDocument = {
      uri = "file:///home/username/batata.scad"
    }
  }
}
[DEBUG][2023-12-16 00:30:19] .../vim/lsp/rpc.lua:387    "rpc.receive"   {
  id = 3,
  jsonrpc = "2.0"
}
```

# The solution ?

I have no idea why this is happening. The tree_sitter function `goto_first_child_for_point` ([docs](https://docs.rs/tree-sitter/latest/tree_sitter/struct.TreeCursor.html#method.goto_first_child_for_point)) is simply returning earlier than it should for the `Point`. My solution is just a simple hack that should fix most/all cases