### PR TITLE
Handle panic on missing `search-paths`

### DIFF
--- a/src/server/handler/notification.rs
+++ b/src/server/handler/notification.rs
@@ -115,7 +115,7 @@ impl Server {
                         .filter_map(|buf| buf.into_os_string().into_string().ok())
                         .collect::<Vec<String>>()
                 })
-                .unwrap();
+                .unwrap_or_default();
 
             self.extend_libs(paths);
 

--- a/src/server/utils.rs
+++ b/src/server/utils.rs
@@ -20,7 +20,7 @@ macro_rules! err_to_console {
 pub(crate) fn find_offset(text: &str, pos: Position) -> Option<usize> {
     let mut offset = 0;
     for _ in 0..pos.line {
-        offset += text[offset..].find('\n')? + 1;
+        offset += text[offset..].find('\n').unwrap_or_default() + 1;
     }
 
     let mut chars = text[offset..].chars();


### PR DESCRIPTION
The config below will panic on an `.unwrap()`
```lua
  openscad_lsp = {
    settings = {
      openscad = {
        fmt_style = "file",
        fmt_exe= "clang-format",
        -- search_paths = "/libs", this will panic if left commented
      },
    },
  }
```

modified `unwrap` to be `unwrap_or_default`