### PR TITLE
Allow usage of custom formatters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,24 +13,24 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
@@ -47,17 +47,17 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -80,33 +80,31 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.0"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
+checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.0"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
  "clap_lex",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.3.0"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -116,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
@@ -183,28 +181,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
-]
-
-[[package]]
-name = "errno"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -229,15 +206,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "idna"
@@ -250,27 +221,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
+name = "is_terminal_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
-dependencies = [
- "hermit-abi",
- "io-lifetimes",
- "rustix",
- "windows-sys",
-]
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -295,12 +249,6 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
@@ -340,12 +288,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "once_cell"
-version = "1.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
-
-[[package]]
 name = "openscad-lsp"
 version = "1.2.5"
 dependencies = [
@@ -378,9 +320,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -430,20 +372,6 @@ name = "regex-syntax"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
-
-[[package]]
-name = "rustix"
-version = "0.37.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
 
 [[package]]
 name = "ryu"
@@ -504,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -656,7 +584,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -665,13 +602,29 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -681,10 +634,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -693,10 +658,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -705,13 +688,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tree-sitter = "0.20.9"
 tree-sitter-openscad = "0.4.2"
 linked-hash-map = "0.5.6"
 shellexpand = "3.1.0"
-clap = {features = ["derive"], version = "4.0.14"}
+clap = {features = ["derive"], version = "4.5.15"}
 lazy_static = "1.4.0"
 regex = "1.6.0"
 directories = "5.0.1"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 openscad-LSP
 ========================
 
-A [LSP](https://microsoft.github.io/language-server-protocol/) (Language Server Protocol) 
-server for [OpenSCAD](https://openscad.org). 
+A [LSP](https://microsoft.github.io/language-server-protocol/) (Language Server Protocol)
+server for [OpenSCAD](https://openscad.org).
 
 inspired by [dzhu/openscad-language-server](https://github.com/dzhu/openscad-language-server)
 
@@ -40,6 +40,8 @@ Install
 openscad-LSP is written in [Rust](https://rust-lang.org), in order to use it, you need to
 install [Rust toolchain](https://www.rust-lang.org/learn/get-started).
 
+To use `scadforamt`, download the binary from the repo's [releases page](https://github.com/hugheaves/scadformat/releases)
+
 ``` {.sh}
 cargo install openscad-lsp
 ```
@@ -58,24 +60,27 @@ Usage
 The server communicates over TCP socket (127.0.0.1:3245).
 
 ```
-USAGE:
-    openscad-lsp [OPTIONS]
+A language(LSP) server for OpenSCAD
 
-OPTIONS:
-        --builtin <BUILTIN>        external builtin functions file path, if set, the built-in
-                                   builtin functions file will not be used [default: ]
-        --fmt-exe <FMT_EXE>        clang format executable file path [default: clang-format]
-        --fmt-style <FMT_STYLE>    LLVM, GNU, Google, Chromium, Microsoft, Mozilla, WebKit, file
-                                   [default: Microsoft]
-    -h, --help                     Print help information
-        --ignore-default           exclude default params in auto-completion
-        --ip <IP>                  [default: 127.0.0.1]
-    -p, --port <PORT>              [default: 3245]
-        --stdio                    use stdio instead of tcp
-    -V, --version                  Print version information
+Usage: openscad-lsp [OPTIONS]
+
+Options:
+  -p, --port <PORT>            [default: 3245]
+      --ip <IP>                [default: 127.0.0.1]
+      --fmt-style <FMT_STYLE>  [possible values: LLVM, GNU, Google, Chromium, Microsoft, Mozilla, Webkit, file]
+      --fmt-exe <FMT_EXE>      formatter executable file path [default: clang-format]
+      --fmt-args <FMT_ARGS>    formatter executable arguments
+      --builtin <BUILTIN>      external builtin functions file path, if set, the built-in builtin functions file will not be used
+      --stdio                  use stdio instead of tcp
+      --ignore-default         exclude default params in auto-completion
+      --depth <DEPTH>          search depth [default: 3]
+  -h, --help                   Print help
+  -V, --version                Print version
 ```
 
-To change the config during running, you can send notification `workspace/didChangeConfiguration` 
+To change the config during running, you can send notification `workspace/didChangeConfiguration`
+
+`clang-format` formatting config:
 
 ```js
 // example
@@ -89,4 +94,27 @@ To change the config during running, you can send notification `workspace/didCha
         }
     }
 }
+```
+
+`scadformat` formatting config:
+
+```js
+{
+    "settings": {
+        "openscad": {
+            "search_paths": "/libs",
+            "fmt_exe": "scadformat",
+            "fmt_args": "--log-level error",
+            "default_param": true
+        }
+    }
+}
+```
+
+To format on write with neovim, include the text below in your `init.lua`:
+```lua
+autocmd("BufWritePre", {
+  pattern = {"*.scad" },
+  callback = function() vim.lsp.buf.format() end,
+})
 ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Usage: openscad-lsp [OPTIONS]
 Options:
   -p, --port <PORT>            [default: 3245]
       --ip <IP>                [default: 127.0.0.1]
-      --fmt-style <FMT_STYLE>  [possible values: LLVM, GNU, Google, Chromium, Microsoft, Mozilla, Webkit, file]
+      --fmt-style <FMT_STYLE>  formatting style for clang-format [possible values: LLVM, GNU, Google, Chromium, Microsoft, Mozilla, Webkit, file]
       --fmt-exe <FMT_EXE>      formatter executable file path [default: clang-format]
       --fmt-args <FMT_ARGS>    formatter executable arguments
       --builtin <BUILTIN>      external builtin functions file path, if set, the built-in builtin functions file will not be used

--- a/src/builtins
+++ b/src/builtins
@@ -652,14 +652,14 @@ cube and render it (F6). If the polyhedron disappears, it means that it
 is not correct. Revise the winding order of all faces and the two rules
 stated above.
 
-#### Mis-ordered faces
+#### Misordered faces
 
 ------------------------------------------------------------------------
 
-**Example 4** a more complex polyhedron with mis-ordered faces
+**Example 4** a more complex polyhedron with misordered faces
 
 When you select 'Thrown together' from the view menu and **compile** the
-design (**not** compile and render!) the preview shows the mis-oriented
+design (**not** compile and render!) the preview shows the misoriented
 polygons highlighted. Unfortunately this highlighting is not possible in
 the OpenCSG preview mode because it would interfere with the way the
 OpenCSG preview mode is implemented.)
@@ -722,7 +722,7 @@ polyhedron(
 Beginner's tip  
 
 If you don't really understand "orientation", try to identify the
-mis-oriented pink faces and then invert the sequence of the references
+misoriented pink faces and then invert the sequence of the references
 to the points vectors until you get it right. E.g. in the above example,
 the third triangle (*[0,4,5]*) was wrong and we fixed it as
 *[4,0,5]*. Remember that a face list is a circular list. In addition,
@@ -3443,7 +3443,7 @@ Right-hand grip rule
 
 You must use parameter names due to a backward compatibility issue.
 
-**convexity** : If the extrusion fails for a non-trival 2D shape, try
+**convexity** : If the extrusion fails for a non-trivial 2D shape, try
 setting the convexity parameter (the default is not 10, but 10 is a
 "good" value to try). See explanation further down.
 
@@ -3813,7 +3813,7 @@ echo(concat([ [1], [2] ], [[3]])); // produces ECHO: [[1], [2], [3]]
 ***Note:*** All vectors passed to the function lose one nesting level.
 When adding something like a single element [x, y, z] tuples (which
 are vectors, too), the tuple needs to be enclosed in a vector (i.e. an
-extra set of brackets) before the concatenation. in the exmple below, a
+extra set of brackets) before the concatenation. in the example below, a
 fourth point is added to the polygon path, which used to resemble a
 triangle, making it a square now:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,31 +10,42 @@ use server::*;
 use std::error::Error;
 
 #[derive(Parser)]
-#[clap(name = "OpenSCAD-LSP")]
-#[clap(author, version, about)]
+#[command(name = "OpenSCAD-LSP")]
+#[command(author, version, about)]
 pub(crate) struct Cli {
-    #[clap(short, long, default_value_t = String::from("3245"))]
+    #[arg(short, long, default_value_t = String::from("3245"))]
     port: String,
 
-    #[clap(long, default_value_t = String::from("127.0.0.1"))]
+    #[arg(long, default_value_t = String::from("127.0.0.1"))]
     ip: String,
 
-    #[clap(long, default_value_t = String::from("Microsoft"), help = "LLVM, GNU, Google, Chromium, Microsoft, Mozilla, WebKit, file")]
-    fmt_style: String,
+    #[arg(
+        long,
+        default_value_if("fmt_exe", "clang-format", Some("Microsoft")),
+        value_parser = ["LLVM", "GNU", "Google", "Chromium", "Microsoft", "Mozilla", "Webkit", "file"]
+    )]
+    fmt_style: Option<String>,
 
-    #[clap(long, default_value_t = String::from("clang-format"), help = "clang format executable file path")]
+    #[arg(
+        long,
+        default_value = "clang-format",
+        help = "formatter executable file path"
+    )]
     fmt_exe: String,
 
-    #[clap(long, default_value_t = String::from(""), help = "external builtin functions file path, if set, the built-in builtin functions file will not be used")]
-    builtin: String,
+    #[arg(
+        long,
+        help = "external builtin functions file path, if set, the built-in builtin functions file will not be used"
+    )]
+    builtin: Option<String>,
 
-    #[clap(long, help = "use stdio instead of tcp")]
+    #[arg(long, help = "use stdio instead of tcp")]
     stdio: bool,
 
-    #[clap(long, help = "exclude default params in auto-completion")]
+    #[arg(long, help = "exclude default params in auto-completion")]
     ignore_default: bool,
 
-    #[clap(long, default_value_t = 3, help = "search depth")]
+    #[arg(long, default_value_t = 3, help = "search depth")]
     depth: i32,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,9 @@ pub(crate) struct Cli {
     )]
     fmt_exe: String,
 
+    #[arg(long, help = "formatter executable arguments")]
+    fmt_args: Vec<String>,
+
     #[arg(
         long,
         help = "external builtin functions file path, if set, the built-in builtin functions file will not be used"

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,8 @@ pub(crate) struct Cli {
 
     #[arg(
         long,
-        default_value_if("fmt_exe", "clang-format", Some("Microsoft")),
-        value_parser = ["LLVM", "GNU", "Google", "Chromium", "Microsoft", "Mozilla", "Webkit", "file"]
+        value_parser = ["LLVM", "GNU", "Google", "Chromium", "Microsoft", "Mozilla", "Webkit", "file"],
+        help = "formatting style for clang-format",
     )]
     fmt_style: Option<String>,
 

--- a/src/server/handler/notification.rs
+++ b/src/server/handler/notification.rs
@@ -89,6 +89,7 @@ impl Server {
             search_paths: Option<String>,
             fmt_style: Option<String>,
             fmt_exe: Option<String>,
+            fmt_args: Vec<String>,
             default_param: Option<bool>,
         }
 
@@ -129,6 +130,10 @@ impl Server {
                 if !fmt_exe.trim().is_empty() && self.args.fmt_exe != fmt_exe {
                     self.args.fmt_exe = fmt_exe;
                 }
+            }
+
+            if !settings.openscad.fmt_args.is_empty() {
+                self.args.fmt_args = settings.openscad.fmt_args;
             }
 
             if let Some(default_param) = settings.openscad.default_param {

--- a/src/server/handler/notification.rs
+++ b/src/server/handler/notification.rs
@@ -120,8 +120,8 @@ impl Server {
             self.extend_libs(paths);
 
             if let Some(style) = settings.openscad.fmt_style {
-                if !style.trim().is_empty() && self.args.fmt_style != style {
-                    self.args.fmt_style = style;
+                if !style.trim().is_empty() && self.args.fmt_style.as_ref() != Some(&style) {
+                    self.args.fmt_style = Some(style);
                 }
             }
 

--- a/src/server/handler/request.rs
+++ b/src/server/handler/request.rs
@@ -621,10 +621,10 @@ impl Server {
         let path = uri.to_file_path().unwrap();
         let path = path.parent().unwrap();
         let mut fmt_cmd = Command::new(&self.args.fmt_exe);
-        if let Some(style) = &self.args.fmt_style {
-            fmt_cmd.arg(format!("-style={style}"));
-        }
         if is_clang_format {
+            if let Some(style) = &self.args.fmt_style {
+                fmt_cmd.arg(format!("-style={style}"));
+            }
             fmt_cmd.arg("-assume-filename=foo.scad");
         }
         for args in &self.args.fmt_args {

--- a/src/server/handler/request.rs
+++ b/src/server/handler/request.rs
@@ -209,7 +209,7 @@ impl Server {
                 .is_some_and(|node| node.kind() == "assignment");
             let is_assignment_in_subscope = is_assignment && node != ident_initial_node;
             if is_assignment_in_subscope {
-                // Unwrap is ok because an identifier node whould always have a parent scope.
+                // Unwrap is ok because an identifier node would always have a parent scope.
                 let scope = find_node_scope(node).unwrap();
                 // Consume iterator until it reaches the parent scope
                 while node_iter.next().is_some_and(|next| scope != next) {}

--- a/src/server/handler/request.rs
+++ b/src/server/handler/request.rs
@@ -620,9 +620,14 @@ impl Server {
         let path = uri.to_file_path().unwrap();
         let path = path.parent().unwrap();
 
-        let child = match Command::new(&self.args.fmt_exe)
-            .arg(format!("-style={}", self.args.fmt_style))
-            .arg("-assume-filename=foo.scad")
+        let mut fmt_cmd = Command::new(&self.args.fmt_exe);
+        if let Some(style) = &self.args.fmt_style {
+            fmt_cmd.arg(format!("-style={style}"));
+        }
+        if self.args.fmt_exe.ends_with("clang-format") {
+            fmt_cmd.arg("-assume-filename=foo.scad");
+        }
+        let child = match fmt_cmd
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .current_dir(path)

--- a/src/server/handler/request.rs
+++ b/src/server/handler/request.rs
@@ -583,13 +583,13 @@ impl Server {
             _ => return,
         };
 
-        let internal_err = |err: String| {
+        let internal_err = |message: String| {
             self.respond(Response {
                 id: id.clone(),
                 result: None,
                 error: Some(ResponseError {
                     code: -32603,
-                    message: err,
+                    message,
                     data: None,
                 }),
             });

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -105,7 +105,7 @@ impl Server {
             let lib_path = if cfg!(target_os = "windows") {
                 userdir
                     .document_dir()?
-                    .join("\\OpenSCAD\\libraries\\")
+                    .join("OpenSCAD\\libraries\\")
                     .into_os_string()
                     .into_string()
             } else if cfg!(target_os = "macos") {
@@ -156,7 +156,7 @@ impl Server {
                     return None;
                 }
 
-                let mut path = format!("file://{}", p);
+                let mut path = format!("file://{p}");
                 if !path.ends_with('/') {
                     path.push('/');
                 }

--- a/src/server/response_item.rs
+++ b/src/server/response_item.rs
@@ -156,15 +156,15 @@ impl Item {
             None => self.make_label(),
         };
         label = match self.kind {
-            ItemKind::Function { .. } => format!("```scad\nfunction {}\n```", label),
-            ItemKind::Module { .. } => format!("```scad\nmodule {}\n```", label),
-            _ => format!("```scad\n{}\n```", label),
+            ItemKind::Function { .. } => format!("```scad\nfunction {label}\n```"),
+            ItemKind::Module { .. } => format!("```scad\nmodule {label}\n```"),
+            _ => format!("```scad\n{label}\n```"),
         };
         if let Some(doc) = &self.doc {
             if self.is_builtin {
-                label = format!("{}\n---\n\n{}\n", label, doc);
+                label = format!("{label}\n---\n\n{doc}\n");
             } else {
-                label = format!("{}\n---\n\n<pre>\n{}\n</pre>\n", label, doc);
+                label = format!("{label}\n---\n\n<pre>\n{doc}\n</pre>\n");
             }
         }
         // print!("{}", &label);

--- a/src/server/utils.rs
+++ b/src/server/utils.rs
@@ -144,7 +144,7 @@ impl NodeExt for Node<'_> {
 pub(crate) trait KindExt {
     fn is_include_statement(&self) -> bool;
     fn is_comment(&self) -> bool;
-    fn is_callable(&self) -> bool;
+    fn _is_callable(&self) -> bool;
 }
 
 impl KindExt for str {
@@ -156,7 +156,7 @@ impl KindExt for str {
         self == "comment"
     }
 
-    fn is_callable(&self) -> bool {
+    fn _is_callable(&self) -> bool {
         self == "module_declaration" || self == "function_declaration"
     }
 }


### PR DESCRIPTION
Added `fmt_args` and allowed `fmt_exe` to handle other formatters such as `scadformat`: https://github.com/hugheaves/scadformat

* handled typos
* addressed clippy warnings
* added documentation for new formatting