### PR TITLE
 Track Cargo.lock and add CI consistency check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,3 +71,17 @@ jobs:
         with:
           command: clippy
           args: --all-features --all-targets -- -D warnings
+
+  lockfile:
+    name: Cargo.lock up-to-date?
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Check if Cargo.lock is up-to-date
+        run: cargo generate-lockfile --locked
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /target
-/Cargo.lock
 **/*.log


### PR DESCRIPTION
This PR fixes #42:
- Removes `Cargo.lock` from `.gitignore` so it can be tracked for reproducible builds.
- Adds a GitHub Actions CI check to ensure `Cargo.lock` stays in sync with `Cargo.toml`.

Note:
After merging, maintainers should manually update and commit `Cargo.lock` to pass the new CI check.
