### PR TITLE
 fix(tree-sitter): Parser fails on floats ending with a period

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,7 +629,7 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openscad-lsp"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "clap",
  "directories",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,9 +1026,9 @@ checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
 
 [[package]]
 name = "tree-sitter-openscad-ng"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642006b2d92a2381fb1edb3216482ef442879a7732ebe81796a1f26993903b9b"
+checksum = "aa00e191bb0053fe78d58edce19a3475da399d3c25caf89c56c8b72b894b236f"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openscad-lsp"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 authors = ["Leathong"]
 description = "A language(LSP) server for OpenSCAD"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ repository = "https://github.com/Leathong/openscad-LSP"
 
 [dependencies]
 lsp-server = "0.7.8"
-lsp-types = "0.94.0"
+lsp-types = "0.94.1"
 serde = "1.0.219"
-serde_json = "1.0.86"
-tree-sitter = "0.25.4"
-tree-sitter-openscad-ng = "0.6.0"
+serde_json = "1.0.140"
+tree-sitter = "0.25.5"
+tree-sitter-openscad-ng = "0.6.1"
 linked-hash-map = "0.5.6"
 shellexpand = "3.1.1"
-clap = {features = ["derive"], version = "4.5.38"}
+clap = {features = ["derive"], version = "4.5.39"}
 lazy_static = "1.5.0"
 regex = "1.11.1"
 directories = "6.0.0"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,29 @@
+green := "\\033[32m"
+yellow := "\\033[33m"
+reset := "\\033[0m"
+
+# generate builtins
+gen:
+    echo 'builtins'
+
+# catchall lints
+lint:
+    typos
+    just --fmt --check
+    cargo clippy --all-targets --all-features -- -W clippy::unused_async -W clippy::uninlined_format_args -W clippy::unnecessary_mut_passed
+
+# formats rust and justfile code
+fmt:
+    cargo fmt
+    just --fmt --unstable
+
+# updates cargo and dist dependencies
+update:
+    cargo upgrade && cargo update
+    dist init -y
+
+# updates node package.json to latest available
+outdated:
+    @printf '{{ yellow }}={{ reset }}Cargo{{ yellow }}={{ reset }}\n'
+    cargo outdated -d 1
+    @printf '{{ yellow }}======={{ reset }}\n'

--- a/src/topiary.rs
+++ b/src/topiary.rs
@@ -42,7 +42,7 @@ pub fn format(
         &language,
         Operation::Format {
             // We only enable the idempotency check in debug mode: it's useful to detect bugs in
-            // the Nickel formatter, but we don't want to report an error or to make production
+            // the Topiary formatter, but we don't want to report an error or to make production
             // users pay the cost of the check, although this cost should be fairly low.
             skip_idempotence: !cfg!(debug_assertions),
             tolerate_parsing_errors: false,


### PR DESCRIPTION
Fixes https://github.com/Leathong/openscad-LSP/issues/47
Upstream PR: https://github.com/openscad/tree-sitter-openscad/pull/4

Trailing decimals would previously fail to parse:
```openscad
pA = [ 0., 0. ];
pB = [ 0.5, 0.866025 ];
pC = [ 1., 0. ];
```




* Added root level [justfile](https://github.com/casey/just) (`cargo install just`)
  just will allow some combined flows: `just lint` (checks typos and lints more than rust files)