### PR TITLE
fix: switch to gen-lsp-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,12 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +307,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gen-lsp-types"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b8ec601e62362b666a3def1fed667ee87b10a4507402618376d142a05373c6"
+dependencies = [
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,19 +536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lsp-types"
-version = "0.95.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e34d33a8e9b006cd3fc4fe69a921affa097bae4bb65f76271f4644f9a334365"
-dependencies = [
- "bitflags",
- "serde",
- "serde_json",
- "serde_repr",
- "url",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,10 +559,10 @@ version = "2.0.2"
 dependencies = [
  "clap",
  "directories",
+ "gen-lsp-types",
  "lazy_static",
  "linked-hash-map",
  "lsp-server",
- "lsp-types",
  "regex",
  "serde",
  "serde_json",
@@ -739,17 +731,6 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -939,9 +920,9 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-openscad-ng"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0addc06c4e9c9349a3ae038c20aa8297bc4d48d9c1ce09e13f4e04a15d435945"
+checksum = "a9286371873e82cb888be0d9394dd3c6a6aaca66fa2fd31879baafb2e4008488"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -85,9 +85,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -342,12 +342,13 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -355,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -368,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -382,15 +383,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -402,15 +403,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -434,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -444,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -469,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -491,15 +492,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
@@ -512,9 +513,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -599,9 +600,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -822,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -832,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "pin-project-lite",
  "tokio-macros",
@@ -842,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1073,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yansi"
@@ -1085,9 +1086,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -1096,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1108,18 +1109,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1129,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -1140,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1151,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/Leathong/openscad-LSP"
 
 [dependencies]
 lsp-server = "0.7.9"
-lsp-types = "0.95.1"
+lsp-types = { package = "gen-lsp-types", version = "0.4.0", features = ["url"]}
 serde = "1.0.228"
 serde_json = "1.0.145"
 tree-sitter = "0.25.10"

--- a/src/server/code_helper.rs
+++ b/src/server/code_helper.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, fs::read_to_string, io, rc::Rc};
 
-use lsp_types::Url;
+use lsp_types::Uri;
 use tree_sitter::Node;
 
 use crate::{
@@ -12,24 +12,24 @@ use crate::{
 
 // Code-related helpers.
 impl Server {
-    pub(crate) fn get_code(&mut self, uri: &Url) -> Option<Rc<RefCell<ParsedCode>>> {
+    pub(crate) fn get_code(&mut self, uri: &Uri) -> Option<Rc<RefCell<ParsedCode>>> {
         match self.codes.get(uri) {
             Some(x) => Some(Rc::clone(x)),
             None => self.read_and_cache(uri.clone()).ok(),
         }
     }
 
-    pub(crate) fn insert_code(&mut self, url: Url, code: String) -> Rc<RefCell<ParsedCode>> {
+    pub(crate) fn insert_code(&mut self, uri: Uri, code: String) -> Rc<RefCell<ParsedCode>> {
         while self.codes.len() > 1000 {
             self.codes.pop_front();
         }
 
         let rc = Rc::new(RefCell::new(ParsedCode::new(
             code,
-            url.clone(),
+            uri.clone(),
             self.library_locations.clone(),
         )));
-        self.codes.insert(url, rc.clone());
+        self.codes.insert(uri, rc.clone());
         rc
     }
 
@@ -161,18 +161,18 @@ impl Server {
         result
     }
 
-    pub(crate) fn read_and_cache(&mut self, url: Url) -> io::Result<Rc<RefCell<ParsedCode>>> {
-        let text = read_to_string(url.to_file_path().unwrap())?;
+    pub(crate) fn read_and_cache(&mut self, uri: Uri) -> io::Result<Rc<RefCell<ParsedCode>>> {
+        let text = read_to_string(uri.to_file_path().unwrap())?;
 
-        match self.codes.entry(url.clone()) {
+        match self.codes.entry(uri.clone()) {
             linked_hash_map::Entry::Occupied(o) => {
                 if o.get().borrow().code != text {
-                    Ok(self.insert_code(url, text))
+                    Ok(self.insert_code(uri, text))
                 } else {
                     Ok(Rc::clone(o.get()))
                 }
             }
-            linked_hash_map::Entry::Vacant(_) => Ok(self.insert_code(url, text)),
+            linked_hash_map::Entry::Vacant(_) => Ok(self.insert_code(uri, text)),
         }
     }
 }

--- a/src/server/handler/mod.rs
+++ b/src/server/handler/mod.rs
@@ -2,14 +2,10 @@ use std::error::Error;
 
 use lsp_server::{ExtractError, Message, Response};
 use lsp_types::{
-    notification::{
-        DidChangeConfiguration, DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument,
-        DidSaveTextDocument,
-    },
-    request::{
-        Completion, DocumentSymbolRequest, Formatting, GotoDefinition, HoverRequest,
-        PrepareRenameRequest, Rename,
-    },
+    CompletionRequest, DefinitionRequest, DidChangeConfigurationNotification,
+    DidChangeTextDocumentNotification, DidCloseTextDocumentNotification,
+    DidOpenTextDocumentNotification, DidSaveTextDocumentNotification, DocumentFormattingRequest,
+    DocumentSymbolRequest, HoverRequest, PrepareRenameRequest, RenameRequest,
 };
 use serde_json::json;
 
@@ -68,12 +64,12 @@ impl Server {
                 }
 
                 let req = proc_req!(req, HoverRequest, handle_hover);
-                let req = proc_req!(req, Completion, handle_completion);
-                let req = proc_req!(req, GotoDefinition, handle_definition);
+                let req = proc_req!(req, CompletionRequest, handle_completion);
+                let req = proc_req!(req, DefinitionRequest, handle_definition);
                 let req = proc_req!(req, DocumentSymbolRequest, handle_document_symbols);
-                let req = proc_req!(req, Formatting, handle_formatting);
+                let req = proc_req!(req, DocumentFormattingRequest, handle_formatting);
                 let req = proc_req!(req, PrepareRenameRequest, handle_prepare_rename);
-                let req = proc_req!(req, Rename, handle_rename);
+                let req = proc_req!(req, RenameRequest, handle_rename);
                 err_to_console!("unknown request: {:?}", req);
             }
             Message::Response(resp) => {
@@ -98,11 +94,31 @@ impl Server {
                     };
                 }
 
-                let noti = proc!(noti, DidOpenTextDocument, handle_did_open_text_document);
-                let noti = proc!(noti, DidChangeTextDocument, handle_did_change_text_document);
-                let noti = proc!(noti, DidSaveTextDocument, handle_did_save_text_document);
-                let noti = proc!(noti, DidCloseTextDocument, handle_did_close_text_document);
-                let noti = proc!(noti, DidChangeConfiguration, handle_did_change_config);
+                let noti = proc!(
+                    noti,
+                    DidOpenTextDocumentNotification,
+                    handle_did_open_text_document
+                );
+                let noti = proc!(
+                    noti,
+                    DidChangeTextDocumentNotification,
+                    handle_did_change_text_document
+                );
+                let noti = proc!(
+                    noti,
+                    DidSaveTextDocumentNotification,
+                    handle_did_save_text_document
+                );
+                let noti = proc!(
+                    noti,
+                    DidCloseTextDocumentNotification,
+                    handle_did_close_text_document
+                );
+                let noti = proc!(
+                    noti,
+                    DidChangeConfigurationNotification,
+                    handle_did_change_config
+                );
 
                 err_to_console!("unknown notification: {:?}", noti);
             }

--- a/src/server/handler/notification.rs
+++ b/src/server/handler/notification.rs
@@ -3,7 +3,7 @@ use std::{env, path::PathBuf};
 use lsp_types::{
     Diagnostic, DiagnosticSeverity, DidChangeConfigurationParams, DidChangeTextDocumentParams,
     DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
-    PublishDiagnosticsParams,
+    PublishDiagnosticsParams, TextDocumentContentChangeEvent, TextDocumentContentChangePartial,
 };
 use serde::Deserialize;
 
@@ -25,10 +25,16 @@ impl Server {
             content_changes,
         } = params;
 
-        let pc = match self.codes.get_refresh(&text_document.uri) {
+        let pc = match self
+            .codes
+            .get_refresh(&text_document.text_document_identifier.uri)
+        {
             Some(x) => x,
             None => {
-                err_to_console!("unknown document {}", text_document.uri);
+                err_to_console!(
+                    "unknown document {}",
+                    text_document.text_document_identifier.uri
+                );
                 return;
             }
         };
@@ -39,7 +45,7 @@ impl Server {
             .into_iter()
             .map(|node| Diagnostic {
                 range: node.lsp_range(),
-                severity: Some(DiagnosticSeverity::ERROR),
+                severity: Some(DiagnosticSeverity::Error),
                 message: if node.is_missing() {
                     format!("missing {}", node.kind())
                 } else {
@@ -50,14 +56,16 @@ impl Server {
             .collect();
 
         if content_changes.len() == 1 {
-            if let Some(range) = content_changes[0].range {
+            if let TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                TextDocumentContentChangePartial { range, .. },
+            ) = content_changes[0]
+            {
                 let bpc = pc.borrow();
                 let pos = to_point(range.start);
                 let mut cursor = bpc.tree.root_node().walk();
                 cursor.goto_first_child_for_point(pos);
                 let node = cursor.node();
                 let kind = node.kind();
-                // let text = node_text(&bpc.code, &node);
 
                 if kind.is_include_statement() && bpc.get_include_url(&node).is_none() {
                     let mut range = node.child(1).unwrap().lsp_range();
@@ -65,7 +73,7 @@ impl Server {
                     range.end.character -= 1;
                     diags.push(Diagnostic {
                         range,
-                        severity: Some(DiagnosticSeverity::ERROR),
+                        severity: Some(DiagnosticSeverity::Error),
                         message: "file not found!".to_owned(),
                         ..Default::default()
                     });
@@ -76,7 +84,7 @@ impl Server {
         self.notify(lsp_server::Notification::new(
             "textDocument/publishDiagnostics".into(),
             PublishDiagnosticsParams {
-                uri: text_document.uri,
+                uri: text_document.text_document_identifier.uri,
                 diagnostics: diags,
                 version: Some(text_document.version),
             },

--- a/src/server/handler/request.rs
+++ b/src/server/handler/request.rs
@@ -6,11 +6,11 @@ use std::{
 
 use lsp_server::{ErrorCode, RequestId, Response, ResponseError};
 use lsp_types::{
-    CompletionItem, CompletionItemKind, CompletionList, CompletionParams, CompletionResponse,
-    DocumentFormattingParams, DocumentSymbolParams, DocumentSymbolResponse, Documentation,
-    GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverContents, HoverParams,
-    InsertTextFormat, InsertTextMode, Location, MarkupContent, Range, RenameParams,
-    SymbolInformation, TextDocumentPositionParams, TextEdit, WorkspaceEdit,
+    BaseSymbolInformation, CompletionItem, CompletionItemKind, CompletionList, CompletionParams,
+    CompletionResponse, Contents, DefinitionParams, DefinitionResponse, DocumentFormattingParams,
+    DocumentSymbolParams, DocumentSymbolResponse, Documentation, Hover, HoverParams,
+    InsertTextFormat, InsertTextMode, Location, MarkupContent, PrepareRenameParams, Range,
+    RenameParams, SymbolInformation, TextEdit, WorkspaceEdit,
 };
 
 use tree_sitter::{Node, Point};
@@ -31,12 +31,8 @@ fn get_node_at_point<'a>(parsed_code: &'a Ref<'_, ParsedCode>, point: Point) -> 
 
 // Request handlers.
 impl Server {
-    pub(crate) fn handle_prepare_rename(
-        &mut self,
-        id: RequestId,
-        params: TextDocumentPositionParams,
-    ) {
-        let uri = params.text_document.uri;
+    pub(crate) fn handle_prepare_rename(&mut self, id: RequestId, params: PrepareRenameParams) {
+        let uri = params.text_document_position_params.text_document.uri;
 
         let file = match self.get_code(&uri) {
             Some(code) => code,
@@ -45,7 +41,10 @@ impl Server {
         file.borrow_mut().gen_top_level_items_if_needed();
         let bfile = file.borrow();
 
-        let node = get_node_at_point(&bfile, to_point(params.position));
+        let node = get_node_at_point(
+            &bfile,
+            to_point(params.text_document_position_params.position),
+        );
         if node.kind() != "identifier" {
             self.respond(Response {
                 id,
@@ -108,7 +107,7 @@ impl Server {
         })
     }
     pub(crate) fn handle_rename(&mut self, id: RequestId, params: RenameParams) {
-        let uri = params.text_document_position.text_document.uri;
+        let uri = params.text_document_position_params.text_document.uri;
         let ident_new_name = params.new_name;
 
         let file = match self.get_code(&uri) {
@@ -119,7 +118,10 @@ impl Server {
         let bfile = file.borrow();
 
         let (ident_initial_name, parent_scope, ident_initial_node) = {
-            let node = get_node_at_point(&bfile, to_point(params.text_document_position.position));
+            let node = get_node_at_point(
+                &bfile,
+                to_point(params.text_document_position_params.position),
+            );
             if node.kind() != "identifier" {
                 self.respond(Response {
                     id,
@@ -270,7 +272,7 @@ impl Server {
                     0,
                 );
                 items.first().map(|item| Hover {
-                    contents: HoverContents::Markup(MarkupContent {
+                    contents: Contents::MarkupContent(MarkupContent {
                         kind: lsp_types::MarkupKind::Markdown,
                         value: item.borrow_mut().get_hover(),
                     }),
@@ -288,7 +290,7 @@ impl Server {
         });
     }
 
-    pub(crate) fn handle_definition(&mut self, id: RequestId, params: GotoDefinitionParams) {
+    pub(crate) fn handle_definition(&mut self, id: RequestId, params: DefinitionParams) {
         let uri = &params.text_document_position_params.text_document.uri;
         let pos = params.text_document_position_params.position;
 
@@ -358,7 +360,7 @@ impl Server {
             _ => None,
         };
 
-        let result = result.map(GotoDefinitionResponse::Array);
+        let result = result.map(|result| DefinitionResponse::Definition(result.into()));
         let result = serde_json::to_value(result).unwrap();
 
         self.respond(Response {
@@ -369,8 +371,8 @@ impl Server {
     }
 
     pub(crate) fn handle_completion(&mut self, id: RequestId, params: CompletionParams) {
-        let uri = &params.text_document_position.text_document.uri;
-        let pos = params.text_document_position.position;
+        let uri = &params.text_document_position_params.text_document.uri;
+        let pos = params.text_document_position_params.position;
         let file = match self.get_code(uri) {
             Some(code) => code,
             _ => return,
@@ -478,24 +480,27 @@ impl Server {
                 })
                 .is_some()
         {
-            CompletionResponse::List(CompletionList {
+            CompletionList {
                 is_incomplete: true,
                 items: bfile
                     .get_include_completion(&node)
                     .iter()
                     .map(|file_name| CompletionItem {
                         label: file_name.clone(),
-                        kind: Some(CompletionItemKind::FILE),
+                        kind: Some(CompletionItemKind::File),
                         filter_text: Some(name.to_owned()),
                         insert_text: Some(file_name.clone()),
-                        insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
-                        insert_text_mode: Some(InsertTextMode::ADJUST_INDENTATION),
+                        insert_text_format: Some(InsertTextFormat::PlainText),
+                        insert_text_mode: Some(InsertTextMode::AdjustIndentation),
                         ..Default::default()
                     })
                     .collect(),
-            })
+                item_defaults: None,
+                apply_kind: None,
+            }
+            .into()
         } else {
-            CompletionResponse::List(CompletionList {
+            CompletionResponse::CompletionList(CompletionList {
                 is_incomplete: true,
                 items: items
                     .iter()
@@ -508,10 +513,10 @@ impl Server {
                             filter_text: Some(item.borrow().name.to_owned()),
                             insert_text: Some(snippet),
                             insert_text_format: Some(match item.borrow().kind {
-                                ItemKind::Variable => InsertTextFormat::PLAIN_TEXT,
-                                _ => InsertTextFormat::SNIPPET,
+                                ItemKind::Variable => InsertTextFormat::PlainText,
+                                _ => InsertTextFormat::Snippet,
                             }),
-                            insert_text_mode: Some(InsertTextMode::ADJUST_INDENTATION),
+                            insert_text_mode: Some(InsertTextMode::AdjustIndentation),
                             documentation: item.borrow().hover.as_ref().map(|doc| {
                                 Documentation::MarkupContent(MarkupContent {
                                     kind: lsp_types::MarkupKind::Markdown,
@@ -522,6 +527,8 @@ impl Server {
                         }
                     })
                     .collect(),
+                apply_kind: None,
+                item_defaults: None,
             })
         };
 
@@ -549,21 +556,23 @@ impl Server {
                     item.borrow().url.as_ref().map(|url| {
                         #[allow(deprecated)]
                         SymbolInformation {
-                            name: item.borrow().name.to_owned(),
-                            kind: item.borrow().get_symbol_kind(),
-                            tags: None,
+                            base_symbol_information: BaseSymbolInformation {
+                                name: item.borrow().name.to_owned(),
+                                kind: item.borrow().get_symbol_kind(),
+                                tags: None,
+                                container_name: None,
+                            },
                             deprecated: None,
                             location: Location {
                                 uri: url.clone(),
                                 range: item.borrow().range,
                             },
-                            container_name: None,
                         }
                     })
                 })
                 .collect();
 
-            let result = DocumentSymbolResponse::Flat(result);
+            let result = DocumentSymbolResponse::SymbolInformationList(result);
 
             let result = serde_json::to_value(result).unwrap();
             self.respond(Response {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,8 +13,8 @@ use std::{cell::RefCell, env, path::PathBuf, rc::Rc};
 use linked_hash_map::LinkedHashMap;
 use lsp_server::Connection;
 use lsp_types::{
-    HoverProviderCapability, OneOf, RenameOptions, ServerCapabilities, TextDocumentSyncCapability,
-    TextDocumentSyncKind, Url, WorkDoneProgressOptions,
+    CompletionOptions, RenameOptions, ServerCapabilities, TextDocumentSyncKind, Uri,
+    WorkDoneProgressOptions,
 };
 
 use crate::Cli;
@@ -24,13 +24,13 @@ const BUILTINS_SCAD: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/s
 const BUILTIN_PATH: &str = "/builtin";
 
 pub(crate) struct Server {
-    pub library_locations: Rc<RefCell<Vec<Url>>>,
+    pub library_locations: Rc<RefCell<Vec<Uri>>>,
 
     pub connection: Connection,
-    pub codes: LinkedHashMap<Url, Rc<RefCell<ParsedCode>>>,
+    pub codes: LinkedHashMap<Uri, Rc<RefCell<ParsedCode>>>,
     pub args: Cli,
 
-    builtin_url: Url,
+    builtin_url: Uri,
     fmt_query: Option<String>,
 }
 
@@ -77,7 +77,7 @@ impl Server {
             }
         }
 
-        let url = Url::parse(&format!("file://{}", &args.builtin)).unwrap();
+        let url = Uri::parse(&format!("file://{}", &args.builtin)).unwrap();
 
         let mut instance = Self {
             library_locations: Rc::new(RefCell::new(vec![])),
@@ -154,7 +154,7 @@ impl Server {
     }
 
     pub(crate) fn extend_libs(&mut self, userlibs: Vec<String>) {
-        let ret: Vec<Url> = userlibs
+        let ret: Vec<Uri> = userlibs
             .into_iter()
             .map(|lib| shellexpand::tilde(&lib).to_string())
             .filter_map(|p| {
@@ -167,7 +167,7 @@ impl Server {
                     path.push('/');
                 }
 
-                if let Ok(uri) = Url::parse(&path) {
+                if let Ok(uri) = Uri::parse(&path) {
                     if let Ok(path) = uri.to_file_path() {
                         if path.exists() {
                             return Some(uri);
@@ -196,18 +196,19 @@ impl Server {
 
     pub(crate) fn main_loop(&mut self) -> Result<(), Box<dyn Error + Sync + Send>> {
         let caps = serde_json::to_value(ServerCapabilities {
-            text_document_sync: Some(TextDocumentSyncCapability::Kind(
-                TextDocumentSyncKind::INCREMENTAL,
-            )),
-            completion_provider: Some(Default::default()),
-            definition_provider: Some(OneOf::Left(true)),
-            hover_provider: Some(HoverProviderCapability::Simple(true)),
-            document_symbol_provider: Some(OneOf::Left(true)),
-            document_formatting_provider: Some(OneOf::Left(true)),
-            rename_provider: Some(OneOf::Right(RenameOptions {
-                prepare_provider: Some(true),
-                work_done_progress_options: WorkDoneProgressOptions::default(),
-            })),
+            text_document_sync: Some(TextDocumentSyncKind::Incremental.into()),
+            completion_provider: Some(CompletionOptions::default()),
+            definition_provider: Some(true.into()),
+            hover_provider: Some(true.into()),
+            document_symbol_provider: Some(true.into()),
+            document_formatting_provider: Some(true.into()),
+            rename_provider: Some(
+                RenameOptions {
+                    prepare_provider: Some(true),
+                    work_done_progress_options: WorkDoneProgressOptions::default(),
+                }
+                .into(),
+            ),
             ..Default::default()
         })?;
         self.connection.initialize(caps)?;

--- a/src/server/parse_code.rs
+++ b/src/server/parse_code.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, path::PathBuf, rc::Rc};
 
 use lazy_static::lazy_static;
-use lsp_types::{TextDocumentContentChangeEvent, Url};
+use lsp_types::{TextDocumentContentChangeEvent, TextDocumentContentChangePartial, Uri};
 use tree_sitter::{InputEdit, Node, Point, Tree, TreeCursor};
 
 use crate::response_item::{Item, ItemKind};
@@ -27,17 +27,17 @@ pub(crate) struct ParsedCode {
     pub parser: tree_sitter::Parser,
     pub code: String,
     pub tree: Tree,
-    pub url: Url,
+    pub url: Uri,
     pub root_items: Option<Vec<Rc<RefCell<Item>>>>,
-    pub includes: Option<Vec<Url>>,
+    pub includes: Option<Vec<Uri>>,
     pub is_builtin: bool,
     pub external_builtin: bool,
     pub changed: bool,
-    pub libs: Rc<RefCell<Vec<Url>>>,
+    pub libs: Rc<RefCell<Vec<Uri>>>,
 }
 
 impl ParsedCode {
-    pub(crate) fn new(code: String, url: Url, libs: Rc<RefCell<Vec<Url>>>) -> Self {
+    pub(crate) fn new(code: String, url: Uri, libs: Rc<RefCell<Vec<Uri>>>) -> Self {
         let mut parser = tree_sitter::Parser::new();
         parser
             .set_language(&tree_sitter_openscad::LANGUAGE.into())
@@ -60,37 +60,42 @@ impl ParsedCode {
     pub(crate) fn edit(&mut self, events: &[TextDocumentContentChangeEvent]) {
         let mut old_tree = Some(&mut self.tree);
         for event in events {
-            if let Some(range) = event.range {
-                let start_ofs = find_offset(&self.code, range.start).unwrap();
-                let end_ofs = find_offset(&self.code, range.end).unwrap();
-                self.code.replace_range(start_ofs..end_ofs, &event.text);
+            match event {
+                TextDocumentContentChangeEvent::TextDocumentContentChangePartial(
+                    TextDocumentContentChangePartial { range, text, .. },
+                ) => {
+                    let start_ofs = find_offset(&self.code, range.start).unwrap();
+                    let end_ofs = find_offset(&self.code, range.end).unwrap();
+                    self.code.replace_range(start_ofs..end_ofs, &text);
 
-                let new_end_position = match event.text.rfind('\n') {
-                    Some(ind) => {
-                        let num_newlines = event.text.bytes().filter(|&c| c == b'\n').count();
-                        Point {
-                            row: range.start.line as usize + num_newlines,
-                            column: event.text.len() - ind,
+                    let new_end_position = match text.rfind('\n') {
+                        Some(ind) => {
+                            let num_newlines = text.bytes().filter(|&c| c == b'\n').count();
+                            Point {
+                                row: range.start.line as usize + num_newlines,
+                                column: text.len() - ind,
+                            }
                         }
-                    }
-                    None => Point {
-                        row: range.start.line as usize,
-                        column: range.start.character as usize + event.text.len(),
-                    },
-                };
+                        None => Point {
+                            row: range.start.line as usize,
+                            column: range.start.character as usize + text.len(),
+                        },
+                    };
 
-                old_tree.as_mut().unwrap().edit(&InputEdit {
-                    start_byte: start_ofs,
-                    old_end_byte: end_ofs,
-                    new_end_byte: start_ofs + event.text.len(),
-                    start_position: to_point(range.start),
-                    old_end_position: to_point(range.end),
-                    new_end_position,
-                });
-            } else {
-                old_tree = None;
-                self.code = event.text.clone();
-                break;
+                    old_tree.as_mut().unwrap().edit(&InputEdit {
+                        start_byte: start_ofs,
+                        old_end_byte: end_ofs,
+                        new_end_byte: start_ofs + text.len(),
+                        start_position: to_point(range.start),
+                        old_end_position: to_point(range.end),
+                        new_end_position,
+                    });
+                }
+                TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(event) => {
+                    old_tree = None;
+                    self.code = event.text.clone();
+                    break;
+                }
             }
         }
 
@@ -210,7 +215,7 @@ impl ParsedCode {
         self.includes = Some(inc);
     }
 
-    pub(crate) fn get_include_url(&self, incstat_node: &Node) -> Option<Url> {
+    pub(crate) fn get_include_url(&self, incstat_node: &Node) -> Option<Uri> {
         let mut res = None;
         let include_path = node_text(&self.code, &incstat_node.child(1).unwrap())
             .trim_start_matches(&['<', '\n'][..])

--- a/src/server/parse_code.rs
+++ b/src/server/parse_code.rs
@@ -66,7 +66,7 @@ impl ParsedCode {
                 ) => {
                     let start_ofs = find_offset(&self.code, range.start).unwrap();
                     let end_ofs = find_offset(&self.code, range.end).unwrap();
-                    self.code.replace_range(start_ofs..end_ofs, &text);
+                    self.code.replace_range(start_ofs..end_ofs, text);
 
                     let new_end_position = match text.rfind('\n') {
                         Some(ind) => {
@@ -147,9 +147,9 @@ impl ParsedCode {
                     let doc_str = node_text(&self.code, node);
                     let newdoc = self.extract_doc(doc_str, self.is_builtin);
 
-                    if last.doc.is_some() {
-                        last.doc.as_mut().unwrap().push_str("  \n");
-                        last.doc.as_mut().unwrap().push_str(&newdoc);
+                    if let Some(doc) = &mut last.doc {
+                        doc.push_str("  \n");
+                        doc.push_str(&newdoc);
                     } else {
                         let mut doc = "".to_owned();
                         doc.push_str("  \n");

--- a/src/server/response_item.rs
+++ b/src/server/response_item.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use lsp_types::{CompletionItemKind, Range, SymbolKind, Url};
+use lsp_types::{CompletionItemKind, Range, SymbolKind, Uri};
 use regex::Regex;
 use tree_sitter::Node;
 
@@ -90,10 +90,10 @@ pub(crate) enum ItemKind {
 impl ItemKind {
     pub(crate) const fn completion_kind(&self) -> CompletionItemKind {
         match self {
-            Self::Variable => CompletionItemKind::VARIABLE,
-            Self::Function { .. } => CompletionItemKind::FUNCTION,
-            Self::Keyword(_) => CompletionItemKind::KEYWORD,
-            Self::Module { .. } => CompletionItemKind::MODULE,
+            Self::Variable => CompletionItemKind::Variable,
+            Self::Function { .. } => CompletionItemKind::Function,
+            Self::Keyword(_) => CompletionItemKind::Keyword,
+            Self::Module { .. } => CompletionItemKind::Module,
         }
     }
 }
@@ -103,7 +103,7 @@ pub(crate) struct Item {
     pub name: String,
     pub kind: ItemKind,
     pub range: Range,
-    pub url: Option<Url>,
+    pub url: Option<Uri>,
     pub is_builtin: bool,
 
     pub(crate) doc: Option<String>,
@@ -287,10 +287,10 @@ impl Item {
 
     pub(crate) const fn get_symbol_kind(&self) -> SymbolKind {
         match self.kind {
-            ItemKind::Function { .. } => SymbolKind::FUNCTION,
-            ItemKind::Module { .. } => SymbolKind::MODULE,
-            ItemKind::Variable => SymbolKind::VARIABLE,
-            ItemKind::Keyword(_) => SymbolKind::KEY,
+            ItemKind::Function { .. } => SymbolKind::Function,
+            ItemKind::Module { .. } => SymbolKind::Module,
+            ItemKind::Variable => SymbolKind::Variable,
+            ItemKind::Keyword(_) => SymbolKind::Key,
         }
     }
 }

--- a/src/server/utils.rs
+++ b/src/server/utils.rs
@@ -107,18 +107,18 @@ pub(crate) fn error_nodes(mut cursor: TreeCursor) -> Vec<Node> {
 
 pub(crate) fn cast_request<R>(req: Request) -> Result<(RequestId, R::Params), ExtractError<Request>>
 where
-    R: lsp_types::request::Request,
+    R: lsp_types::Request,
 {
-    req.extract(R::METHOD)
+    req.extract(R::METHOD.as_str())
 }
 
 pub(crate) fn cast_notification<N>(
     notif: lsp_server::Notification,
 ) -> Result<N::Params, ExtractError<lsp_server::Notification>>
 where
-    N: lsp_types::notification::Notification,
+    N: lsp_types::Notification,
 {
-    notif.extract(N::METHOD)
+    notif.extract(N::METHOD.as_str())
 }
 
 pub(crate) trait NodeExt {


### PR DESCRIPTION
[gen-lsp-types](https://github.com/ribru17/gen-lsp-types) is an alternative to the lsp-types crate, with types generated via codegen from the official LSP Metamodel for correctness and completeness.

lsp-types issues fixed in gen-lsp-types:

- https://github.com/gluon-lang/lsp-types/issues/310
- https://github.com/gluon-lang/lsp-types/issues/308
- https://github.com/gluon-lang/lsp-types/issues/284
- https://github.com/gluon-lang/lsp-types/issues/278
- https://github.com/gluon-lang/lsp-types/issues/277
- https://github.com/gluon-lang/lsp-types/issues/260
- https://github.com/gluon-lang/lsp-types/issues/245
- https://github.com/gluon-lang/lsp-types/issues/93